### PR TITLE
Code template regression & update

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -2,6 +2,8 @@
 var util = require('util');
 
 var _ = require('underscore');
+var cheerio = require('cheerio');
+var he = require('he');
 
 var log = require('./log');
 var h = require('./helper');
@@ -119,9 +121,13 @@ core.exportProblem = function(problem, opts) {
   data.testcase = util.inspect(data.testcase || '');
 
   if (opts.tpl === 'detailed') {
+    let desc = data.desc;
+    // Replace <sup/> with '^' as the power operator
+    desc = desc.replace(/<\/sup>/gm, '').replace(/<sup>/gm, '^');
+    desc = he.decode(cheerio.load(desc).root().text());
     // NOTE: wordwrap internally uses '\n' as EOL, so here we have to
     // remove all '\r' in the raw string.
-    const desc = data.desc.replace(/\r\n/g, '\n').replace(/^ /mg, '⁠');
+    desc = desc.replace(/\r\n/g, '\n').replace(/^ /mg, '⁠');
     const wrap = require('wordwrap')(79 - data.comment.line.length);
     data.desc = wrap(desc).split('\n');
   }

--- a/lib/plugins/leetcode.js
+++ b/lib/plugins/leetcode.js
@@ -2,8 +2,6 @@
 var util = require('util');
 
 var _ = require('underscore');
-var cheerio = require('cheerio');
-var he = require('he');
 var request = require('request');
 
 var config = require('../config');
@@ -162,11 +160,7 @@ plugin.getProblem = function(problem, cb) {
     problem.likes = q.likes;
     problem.dislikes = q.dislikes;
 
-    const content = q.translatedContent ? q.translatedContent : q.content;
-    // // Replace <sup/> with '^' as the power operator
-    // content = content.replace(/<\/sup>/gm, '').replace(/<sup>/gm, '^');
-    // problem.desc = he.decode(cheerio.load(content).root().text());
-    problem.desc = content;
+    problem.desc = q.translatedContent ? q.translatedContent : q.content;
 
     problem.templates = JSON.parse(q.codeDefinition);
     problem.testcase = q.sampleTestCase;

--- a/templates/codeonly.tpl
+++ b/templates/codeonly.tpl
@@ -1,1 +1,6 @@
+${comment.start}
+${comment.line} @lc app=${app} id=${fid} lang=${lang}
+${comment.line}
+${comment.line} [${fid}] ${name}
+${comment.end}
 ${code}

--- a/templates/detailed.tpl
+++ b/templates/detailed.tpl
@@ -2,5 +2,17 @@ ${comment.start}
 ${comment.line} @lc app=${app} id=${fid} lang=${lang}
 ${comment.line}
 ${comment.line} [${fid}] ${name}
-${comment.end}
+${comment.line}
+${comment.line} ${link}
+${comment.line}
+${comment.line} ${category}
+${comment.line} ${level} (${percent}%)
+${comment.line} Likes:    ${likes}
+${comment.line} Dislikes: ${dislikes}
+${comment.line} Total Accepted:    ${totalAC}
+${comment.line} Total Submissions: ${totalSubmit}
+${comment.line} Testcase Example:  ${testcase}
+${comment.line}
+{{ desc.forEach(function(x) { }}${comment.line} ${x}
+{{ }) }}${comment.end}
 ${code}


### PR DESCRIPTION
Now:
* "-c" uses `codeonly.tpl` and generates comment with metadata and `[fid] name`
* "-cx" fallbacks to original behavior.

Examples:
"-c":
```bash
C:\Programs\nodejs\node.exe --inspect-brk=41626 bin\leetcode show 1 -c
/*
 * @lc app=leetcode id=1 lang=cpp
 *
 * [1] Two Sum
 */
class Solution {
public:
    vector<int> twoSum(vector<int>& nums, int target) {
        
    }
};
```
"-cx":
```bash
C:\Programs\nodejs\node.exe --inspect-brk=30942 bin\leetcode show 1 -cx
/*
 * @lc app=leetcode id=1 lang=cpp
 *
 * [1] Two Sum
 *
 * https://leetcode.com/problems/two-sum/description/
 *
 * algorithms
 * Easy (43.41%)
 * Likes:    10448
 * Dislikes: 345
 * Total Accepted:    1.7M
 * Total Submissions: 3.9M
 * Testcase Example:  '[2,7,11,15]\n9'
 *
 * Given an array of integers, return indices of the two numbers such that they
 * add up to a specific target.
 * 
 * You may assume that each input would have exactly one solution, and you may
 * not use the same element twice.
 * 
 * Example:
 * 
 * 
 * Given nums = [2, 7, 11, 15], target = 9,
 * 
 * Because nums[0] + nums[1] = 2 + 7 = 9,
 * return [0, 1].
 * 
 * 
 * 
 * 
 */
class Solution {
public:
    vector<int> twoSum(vector<int>& nums, int target) {
        
    }
};
```