### PR TITLE
`show` logs meta json if keyword is a filename

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -90,11 +90,15 @@ core.getProblem = function(keyword, cb) {
     if (e) return cb(e);
 
     keyword = Number(keyword) || keyword;
-    const metaFid = file.exist(keyword) ? Number(file.meta(keyword).id) : NaN;
+    const meta = file.exist(keyword) ? file.meta(keyword) : null;
+    const metaFid = meta ? Number(meta.id) : NaN;
     const problem = problems.find(function(x) {
       return x.fid === keyword || x.name === keyword || x.slug === keyword || x.fid === metaFid;
     });
     if (!problem) return cb('Problem not found!');
+    if (meta) { // If keyword is a filename, print the metadata in the first line
+      log.printf('{ "id": "%s", "lang": "%s" }', meta.id, meta.lang);
+    }
     core.next.getProblem(problem, cb);
   });
 };


### PR DESCRIPTION
Example:
![image](https://user-images.githubusercontent.com/20227484/56821499-155d0b80-6881-11e9-8c36-0bfe6990922f.png)
