### PR TITLE
Add ts support (for vscode-leetcode)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -29,7 +29,8 @@ const DEFAULT_CONFIG = {
       'ruby',
       'rust',
       'scala',
-      'swift'
+      'swift',
+      'typescript'
     ],
     urls: {
       // base urls

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -45,7 +45,8 @@ const LANGS = [
   {lang: 'ruby',       ext: '.rb',         style: '#'},
   {lang: 'rust',       ext: '.rs',         style: 'c'},
   {lang: 'scala',      ext: '.scala',      style: 'c'},
-  {lang: 'swift',      ext: '.swift',      style: 'c'}
+  {lang: 'swift',      ext: '.swift',      style: 'c'},
+  {lang: 'typescript', ext: '.ts',         style: 'c'}
 ];
 
 const h = {};

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -136,6 +136,7 @@ describe('helper', function() {
       assert.equal(h.langToExt('scala'), '.scala');
       assert.equal(h.langToExt('swift'), '.swift');
       assert.equal(h.langToExt('rust'), '.rs');
+      assert.equal(h.langToExt('typescript'), '.ts');
     });
   }); // #langToExt
 
@@ -158,6 +159,7 @@ describe('helper', function() {
       assert.equal(h.extToLang('~/leetcode/../file.sql'), 'mysql');
       assert.equal(h.extToLang('/home/skygragon/file.dat'), 'unknown');
       assert.equal(h.extToLang('~/leetcode/file.rs'), 'rust');
+      assert.equal(h.extToLang('~/leetcode/file.ts'), 'typescript');
     });
   }); // #extToLang
 
@@ -182,6 +184,7 @@ describe('helper', function() {
       assert.deepEqual(h.langToCommentStyle('ruby'), RUBY_STYLE);
       assert.deepEqual(h.langToCommentStyle('scala'), C_STYLE);
       assert.deepEqual(h.langToCommentStyle('swift'), C_STYLE);
+      assert.deepEqual(h.langToCommentStyle('typescript'), C_STYLE);
     });
   }); // #langToCommentStyle
 


### PR DESCRIPTION
This PR contains the required changes for the leetcode-cli to enable typescript support.

Then in vscode-leetcode, using this update leetcode-cli, we can enable typescript as well. Here is the PR for that https://github.com/LeetCode-OpenSource/vscode-leetcode/pull/573.

So this PR and PR https://github.com/LeetCode-OpenSource/vscode-leetcode/pull/573 should be merged together.