### PR TITLE
fix: leetcode-cn can not use GitHub login bug

### DIFF
--- a/lib/plugins/leetcode.js
+++ b/lib/plugins/leetcode.js
@@ -540,10 +540,16 @@ plugin.login = function(user, cb) {
 };
 
 function parseCookie(cookie, body, cb) {
+  const isCN = config.app === 'leetcode.cn';
   const SessionPattern = /LEETCODE_SESSION=(.+?)(;|$)/;
-  const csrfPattern = /csrftoken=(.+?)(;|$)/;
+  let csrfPattern;
+  if (isCN) {
+    csrfPattern = /name="csrfmiddlewaretoken" value="(.*?)"/;
+  } else {
+    csrfPattern = /csrftoken=(.+?)(;|$)/;
+  }
+  const reCsrfResult = csrfPattern.exec(isCN? body: cookie);
   const reSessionResult = SessionPattern.exec(cookie);
-  const reCsrfResult = csrfPattern.exec(cookie);
   if (reSessionResult === null || reCsrfResult === null) {
     return cb('invalid cookie?');
   }


### PR DESCRIPTION
Last commit caused leetcode-cn can not use third party (LinkedIn and GitHub) login, this pr is to fix that.