### PR TITLE
fix: can't sign in by cookie on leetcode-cn site

### DIFF
--- a/lib/plugins/leetcode.js
+++ b/lib/plugins/leetcode.js
@@ -535,8 +535,7 @@ plugin.login = function(user, cb) {
 
 function parseCookie(cookie, body, cb) {
   const SessionPattern = /LEETCODE_SESSION=(.+?)(;|$)/;
-  let csrfPattern;
-  csrfPattern = /csrftoken=(.+?)(;|$)/;
+  const csrfPattern = /csrftoken=(.+?)(;|$)/;
   const reCsrfResult = csrfPattern.exec(cookie);
   const reSessionResult = SessionPattern.exec(cookie);
   if (reSessionResult === null || reCsrfResult === null) {

--- a/lib/plugins/leetcode.js
+++ b/lib/plugins/leetcode.js
@@ -534,15 +534,10 @@ plugin.login = function(user, cb) {
 };
 
 function parseCookie(cookie, body, cb) {
-  const isCN = config.app === 'leetcode.cn';
   const SessionPattern = /LEETCODE_SESSION=(.+?)(;|$)/;
   let csrfPattern;
-  if (isCN) {
-    csrfPattern = /name="csrfmiddlewaretoken" value="(.*?)"/;
-  } else {
-    csrfPattern = /csrftoken=(.+?)(;|$)/;
-  }
-  const reCsrfResult = csrfPattern.exec(isCN? body: cookie);
+  csrfPattern = /csrftoken=(.+?)(;|$)/;
+  const reCsrfResult = csrfPattern.exec(cookie);
   const reSessionResult = SessionPattern.exec(cookie);
   if (reSessionResult === null || reCsrfResult === null) {
     return cb('invalid cookie?');


### PR DESCRIPTION
This commit fixes the problem where leetcode-cn sign-in by cookie fails. 
It seems like leetcode-cn is now using the same sign-in cookie mechanism as the US site. 