### PR TITLE
Add elixir as a language option

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -232,6 +232,7 @@ Display question details. With `-g`/`-l`/`-x`, the code template would be auto g
     * c
     * cpp
     * csharp
+    * elixir
     * golang
     * java
     * javascript

--- a/lib/config.js
+++ b/lib/config.js
@@ -18,6 +18,7 @@ const DEFAULT_CONFIG = {
       'c',
       'cpp',
       'csharp',
+      'elixir',
       'golang',
       'java',
       'javascript',

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -34,6 +34,7 @@ const LANGS = [
   {lang: 'c',          ext: '.c',          style: 'c'},
   {lang: 'cpp',        ext: '.cpp',        style: 'c'},
   {lang: 'csharp',     ext: '.cs',         style: 'c'},
+  {lang: 'elixir',     ext: '.ex',         style: '#'},
   {lang: 'golang',     ext: '.go',         style: 'c'},
   {lang: 'java',       ext: '.java',       style: 'c'},
   {lang: 'javascript', ext: '.js',         style: 'c'},


### PR DESCRIPTION
I wasn't able to figure out a good way to update any of the stuff in `test/mocks`, so for now this PR just adds the boilerplate throughout the repo for elixir to be a language option. I manually tested this and it all worked as expected. If there is any additional test coverage that should be added, let me know. 

After this is merged/deleted we can update the dependency for the vscode extension. See other [PR here](https://github.com/LeetCode-OpenSource/vscode-leetcode/pull/731)