### PR TITLE
fix: couldn't login to leetcode main site by cookie

### DIFF
--- a/lib/plugins/leetcode.js
+++ b/lib/plugins/leetcode.js
@@ -533,7 +533,7 @@ plugin.login = function(user, cb) {
   });
 };
 
-function parseCookie(cookie, body, cb) {
+function parseCookie(cookie, cb) {
   const SessionPattern = /LEETCODE_SESSION=(.+?)(;|$)/;
   const csrfPattern = /csrftoken=(.+?)(;|$)/;
   const reCsrfResult = csrfPattern.exec(cookie);


### PR DESCRIPTION
Removed the useless parameter `body` of function `parseCookie` so that the third parameter `cb` is at the right place.

Refer to the problem [here](https://github.com/leetcode-tools/leetcode-cli/pull/35#issuecomment-1069034178).