### PR TITLE
Update solution.discuss.js for LeetCode official website update

### DIFF
--- a/lib/plugins/solution.discuss.js
+++ b/lib/plugins/solution.discuss.js
@@ -14,7 +14,7 @@ var plugin = new Plugin(200, 'solution.discuss', '2019.02.03',
     'Plugin to fetch most voted solution in discussions.');
 
 var URL_DISCUSSES = 'https://leetcode.com/graphql';
-var URL_DISCUSS = 'https://leetcode.com/problems/$slug/discuss/$id';
+var URL_DISCUSS = 'https://leetcode.com/problems/$slug/solutions/$id';
 
 function getSolution(problem, lang, cb) {
   if (!problem) return cb();


### PR DESCRIPTION
Now LeetCode officially moved to a new UI and the path of community solutions has been moved from   `https://leetcode.com/problems/trapping-rain-water-ii/discuss/89473/` to   
`https://leetcode.com/problems/trapping-rain-water-ii/solutions/89473/`

This PR reflects the change.