### PR TITLE
fix: remove interpret_expected_id task

### DIFF
--- a/lib/commands/session.js
+++ b/lib/commands/session.js
@@ -1,5 +1,4 @@
 'use strict';
-var prompt = require('prompt');
 
 var h = require('../helper');
 var chalk = require('../chalk');

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -1,7 +1,5 @@
 'use strict';
-var _ = require('underscore');
 var lodash = require('lodash');
-var util = require('util');
 
 var h = require('../helper');
 var file = require('../file');
@@ -78,23 +76,19 @@ function runTest(argv) {
     core.testProblem(problem, function(e, results) {
       if (e) return log.fail(e);
 
-      results = _.sortBy(results, x => x.type);
-      if (results[0].state === 'Accepted')
-        results[0].state = 'Finished';
-      printResult(results[0], null, 'state');
-      printResult(results[0], null, 'error');
+      const result = results[0];
+      if (result.state === 'Accepted')
+        result.state = 'Finished';
+      printResult(result, null, 'state');
+      printResult(result, null, 'error');
 
-      results[0].your_input = problem.testcase;
-      results[0].output = results[0].answer;
-      // LeetCode-CN returns the actual and expected answer into two separate responses
-      if (results[1]) {
-        results[0].expected_answer = results[1].answer;
-      }
-      results[0].stdout = results[0].stdout.slice(1, -1).replace(/\\n/g, '\n');
-      printResult(results[0], null, 'your_input');
-      printResult(results[0], results[0].runtime, 'output');
-      printResult(results[0], null, 'expected_answer');
-      printResult(results[0], null, 'stdout');
+      result.your_input = problem.testcase;
+      result.output = result.answer;
+      result.stdout = result.stdout.slice(1, -1).replace(/\\n/g, '\n');
+      printResult(result, null, 'your_input');
+      printResult(result, result.runtime, 'output');
+      printResult(result, null, 'expected_answer');
+      printResult(result, null, 'stdout');
     });
   });
 }

--- a/lib/plugins/leetcode.js
+++ b/lib/plugins/leetcode.js
@@ -292,14 +292,8 @@ plugin.testProblem = function(problem, cb) {
   runCode(opts, problem, function(e, task) {
     if (e) return cb(e);
 
-    const tasks = [
-      {type: 'Actual', id: task.interpret_id},
-    ];
+    const tasks = [{type: 'Actual', id: task.interpret_id}];
 
-    // Used by LeetCode-CN
-    if (task.interpret_expected_id) {
-      tasks.push({type: 'Expected', id: task.interpret_expected_id});
-    }
     const q = new Queue(tasks, {opts: opts, results: []}, verifyResult);
     q.run(null, function(e, ctx) {
       return cb(e, ctx.results);

--- a/test/plugins/test_leetcode.js
+++ b/test/plugins/test_leetcode.js
@@ -405,11 +405,7 @@ describe('plugin:leetcode', function() {
     it('should ok', function(done) {
       nock('https://leetcode.com')
         .post('/problems/find-the-difference/interpret_solution/')
-        .reply(200, '{"interpret_expected_id": "id1", "interpret_id": "id2"}');
-
-      nock('https://leetcode.com')
-        .get('/submissions/detail/id1/check/')
-        .reply(200, '{"state": "SUCCESS", "run_success": true, "status_msg": "Accepted", "submission_id": "interpret_expected_id1"}');
+        .reply(200, '{"interpret_id": "id2"}');
 
       nock('https://leetcode.com')
         .get('/submissions/detail/id2/check/')
@@ -419,8 +415,6 @@ describe('plugin:leetcode', function() {
         assert.equal(e, null);
         assert.equal(results[0].id, 'id2');
         assert.equal(results[0].ok, false);
-        assert.equal(results[1].id, 'id1');
-        assert.equal(results[1].ok, true);
         done();
       });
     });


### PR DESCRIPTION
According to the latest LeetCode-CN API, the `interpret_id` check has returned `expected_code_answer`.